### PR TITLE
fix create new user db type error

### DIFF
--- a/pages/api/v1/auth/signUp.ts
+++ b/pages/api/v1/auth/signUp.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createUserDb } from "../../../../lib/db";
 import { signUp } from "../../../../lib/firebase";
-
+import generateUsernameFromEmail from "../../../../utils/username-generator";
 type RequestBody = {
   email: string;
   password: string;
@@ -15,12 +15,14 @@ export default async function handler(
 
   try {
     const register = await signUp(email, password);
+    const currentUser = register.user.uid;
+    const username = generateUsernameFromEmail(email);
     const userData = {
-      email: register.user.email,
-      uid: register.user.uid,
+      email: email,
+      displayName: username,
+      uid: currentUser,
     };
     await createUserDb(userData);
-    const currentUser = register.user.uid;
     res.status(200).json({ message: currentUser });
   } catch (err) {
     res.status(500).json({ message: err.code });

--- a/utils/username-generator.ts
+++ b/utils/username-generator.ts
@@ -1,0 +1,14 @@
+export default function generateUsernameFromEmail(email: string) {
+  // Remove everything after the @ symbol.
+  const username = email.split("@")[0];
+
+  // Remove any non-alphanumeric characters and convert to lowercase.
+  const cleanUsername = username.replace(/[^a-z0-9]/gi, "").toLowerCase();
+
+  // Add a random number between 1000 and 9999 to the end of the username to make it unique.
+  const uniqueUsername = `${cleanUsername}${
+    Math.floor(Math.random() * 9000) + 1000
+  }`;
+
+  return uniqueUsername;
+}


### PR DESCRIPTION
I have created a pull request to fix the TypeError that was occurring when creating a new user in the database on the signUp page. To fix the issue, I added a new displayName field to the user data, which is randomly generated from the user's email address.

Here's the code for generating new username from user email

```typescript
function generateUsernameFromEmail(email) {
  // Remove everything after the @ symbol.
  const username = email.split('@')[0];

  // Remove any non-alphanumeric characters and convert to lowercase.
  const cleanUsername = username.replace(/[^a-z0-9]/gi, '').toLowerCase();

  // Add a random number between 1000 and 9999 to the end of the username to make it unique.
  const uniqueUsername = `${cleanUsername}${Math.floor(Math.random() * 9000) + 1000}`;

  return uniqueUsername;
}

```

The generateUsernameFromEmail() function takes the user's email address as input and generates a clean and unique username from it.

With this fix, users will now have a randomly generated displayName field (even if they will not provide a new displayName) in addition to their email address, which can be used for display purposes within the app.